### PR TITLE
UnprotectedRootActions URLs should not start with a slash.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/dockerhub/notification/DockerHubWebHook.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerhub/notification/DockerHubWebHook.java
@@ -80,7 +80,7 @@ public class DockerHubWebHook implements UnprotectedRootAction {
     }
 
     public String getUrlName() {
-        return "/" + URL_NAME;
+        return URL_NAME;
     }
 
     @RequirePOST

--- a/src/test/java/org/jenkinsci/plugins/dockerhub/notification/CoordinatorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/dockerhub/notification/CoordinatorTest.java
@@ -156,7 +156,7 @@ public class CoordinatorTest {
 
         @Override
         public String getUrlName() {
-            return "/fake-dockerhub";
+            return "fake-dockerhub";
         }
 
         public void doRespond(StaplerRequest req, StaplerResponse response) throws IOException {


### PR DESCRIPTION
See [JENKINS-2868](https://issues.jenkins-ci.org/browse/JENKINS-28688)

@reviewbybees @erlichmen 