### PR TITLE
Expose tag and pusher in the build environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ In your <a href="https://hub.docker.com/">hub.docker.com</a> repository, you can
 
 <img src="dockerhub.png">
 
+# Environment variables
+
+The following variables will be set in your build environment:
+
+* DOCKER_TRIGGER_REPO_NAME
+* DOCKER_TRIGGER_PUSHER
+* DOCKER_TRIGGER_TAG
+* DOCKER_TRIGGER_DOCKER_HUB_HOST
+
 # Examples
 
 Payloads submitted by the hub:

--- a/src/main/java/org/jenkinsci/plugins/dockerhub/notification/DockerHubWebHook.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerhub/notification/DockerHubWebHook.java
@@ -200,6 +200,8 @@ public class DockerHubWebHook implements UnprotectedRootAction {
     static class JobbMixIn<JobT extends Job<JobT, RunT> & ParameterizedJobMixIn.ParameterizedJob & Queue.Task, RunT extends Run<JobT, RunT> & Queue.Executable> extends ParameterizedJobMixIn<JobT, RunT> {
         public static final String PREFIX = "DOCKER_TRIGGER_";
         public static final String KEY_REPO_NAME = PREFIX + "REPO_NAME";
+        public static final String KEY_PUSHER = PREFIX + "PUSHER";
+        public static final String KEY_TAG = PREFIX + "TAG";
         public static final String KEY_DOCKER_HUB_HOST = PREFIX + "DOCKER_HUB_HOST";
         /**
          * Some breathing room to iterate through most/all of the jobs before the first triggered build starts.
@@ -248,12 +250,17 @@ public class DockerHubWebHook implements UnprotectedRootAction {
             if (isParameterized()) {
                 Collection<ParameterValue> defaults = getDefaultParametersValues();
                 for (ParameterValue value : defaults) {
-                    if (!value.getName().equalsIgnoreCase(KEY_REPO_NAME) && !value.getName().equalsIgnoreCase(KEY_DOCKER_HUB_HOST)) {
+                    if (!value.getName().equalsIgnoreCase(KEY_REPO_NAME)
+                        && !value.getName().equalsIgnoreCase(KEY_PUSHER)
+                        && !value.getName().equalsIgnoreCase(KEY_TAG)
+                        && !value.getName().equalsIgnoreCase(KEY_DOCKER_HUB_HOST)) {
                         parameters.add(value);
                     }
                 }
             }
             parameters.add(new StringParameterValue(KEY_REPO_NAME, payload.getRepoName()));
+            parameters.add(new StringParameterValue(KEY_PUSHER, payload.getPusher()));
+            parameters.add(new StringParameterValue(KEY_TAG, payload.getTag()));
             String host = payload.getCallbackHost();
             if (!StringUtils.isBlank(host)) {
                 parameters.add(new StringParameterValue(KEY_DOCKER_HUB_HOST, host));

--- a/src/main/java/org/jenkinsci/plugins/dockerhub/notification/webhook/WebHookPayload.java
+++ b/src/main/java/org/jenkinsci/plugins/dockerhub/notification/webhook/WebHookPayload.java
@@ -133,6 +133,28 @@ public class WebHookPayload implements Serializable {
         return null;
     }
 
+    public String getPusher() {
+        JSONObject data = getData();
+        if (data != null) {
+            JSONObject push_data = data.optJSONObject("push_data");
+            if (push_data != null) {
+                return push_data.optString("pusher");
+            }
+        }
+        return null;
+    }
+
+    public String getTag() {
+        JSONObject data = getData();
+        if (data != null) {
+            JSONObject push_data = data.optJSONObject("push_data");
+            if (push_data != null) {
+                return push_data.optString("tag");
+            }
+        }
+        return null;
+    }
+
     /**
      * {@link System#currentTimeMillis()} when this object's constructor was called.
      *


### PR DESCRIPTION
Hi, I wanted to get the container tag in my Jenkins hook to trigger a test, so I did this PR. It adds two new environment variables to the build, as provided from the webhook request:
https://hub.docker.com/r/creeatist/chowdr-api/~/settings/webhooks/