### PR TITLE
[JENKINS-35629] Convert to parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,6 @@
     <properties>
         <jenkins.version>1.580.1</jenkins.version>
         <java.level>6</java.level>
-        <findbugs.failOnError>false</findbugs.failOnError>
     </properties>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.580.1</version>
+        <version>2.9</version>
         <relativePath />
     </parent>
 
@@ -42,6 +42,8 @@
 
     <properties>
         <jenkins.version>1.580.1</jenkins.version>
+        <java.level>6</java.level>
+        <findbugs.failOnError>false</findbugs.failOnError>
     </properties>
 
     <scm>
@@ -58,34 +60,16 @@
         </license>
     </licenses>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.2</version>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.2</version>
-                <configuration>
-                    <xmlOutput>true</xmlOutput>
-                    <failOnError>false</failOnError>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
 
@@ -99,12 +83,6 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>async-http-client</artifactId>
             <version>1.7.8</version>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.11</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
Since the plugin was already at an LTS, this plugin update consisted of increasing/removing parent pom entries and changing to https..  Tested against 1.580 and 2.7 with no failures.

@reviewbybees 