### PR TITLE
Add basic support for ACR webhooks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 Only noting significant user-visible or major API changes, not internal code cleanups and minor bug fixes.
 
+## Unreleased
+
+* Add support for ACR webhooks.
+
 ## 2.2.1 (Jan 04, 2018)
 
 * [JENKINS-47736](https://issues.jenkins-ci.org/browse/JENKINS-47736) - 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ The simplest viable configuration looks like this:
         backoff: 1s
 ```
 
+# Configuring Azure Container Registry
+
+You can find a detailed guide on how to configure webhooks on ACR on
+[docs.microsoft.com](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-webhook).
+Use `http://JENKINS/acr-webhook/notify` as "Service URI".
+
 
 # Examples
 

--- a/src/main/java/org/jenkinsci/plugins/registry/notification/webhook/WebHookCrumbExclusion.java
+++ b/src/main/java/org/jenkinsci/plugins/registry/notification/webhook/WebHookCrumbExclusion.java
@@ -25,6 +25,7 @@ package org.jenkinsci.plugins.registry.notification.webhook;
 
 import hudson.Extension;
 import hudson.security.csrf.CrumbExclusion;
+import org.jenkinsci.plugins.registry.notification.webhook.acr.ACRWebHook;
 import org.jenkinsci.plugins.registry.notification.webhook.dockerhub.DockerHubWebHook;
 import org.jenkinsci.plugins.registry.notification.webhook.dockerregistry.DockerRegistryWebHook;
 
@@ -43,11 +44,12 @@ import java.io.IOException;
 public class WebHookCrumbExclusion extends CrumbExclusion {
     private static final String REGISTRY_BASE = "/" + DockerRegistryWebHook.URL_NAME + "/";
     private static final String HUB_BASE = "/" + DockerHubWebHook.URL_NAME + "/";
+    private static final String ACR_BASE = "/" + ACRWebHook.URL_NAME + "/";
 
     @Override
     public boolean process(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
         String pathInfo = request.getPathInfo();
-        if (pathInfo != null && (pathInfo.startsWith(REGISTRY_BASE) || pathInfo.startsWith(HUB_BASE))) {
+        if (pathInfo != null && (pathInfo.startsWith(REGISTRY_BASE) || pathInfo.startsWith(HUB_BASE) || pathInfo.startsWith(ACR_BASE))) {
             chain.doFilter(request, response);
             return true;
         }

--- a/src/main/java/org/jenkinsci/plugins/registry/notification/webhook/acr/ACRPushNotification.java
+++ b/src/main/java/org/jenkinsci/plugins/registry/notification/webhook/acr/ACRPushNotification.java
@@ -4,6 +4,7 @@ import hudson.Util;
 import hudson.model.Cause;
 import hudson.model.ParameterValue;
 import hudson.model.StringParameterValue;
+import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.registry.notification.webhook.PushNotification;
 import org.jenkinsci.plugins.registry.notification.webhook.WebHookPayload;
@@ -22,7 +23,15 @@ public class ACRPushNotification extends PushNotification {
 
     public ACRPushNotification(ACRWebHookPayload webHookPayload, String repoName) {
         super(webHookPayload);
-        this.tag = webHookPayload.getData().getJSONObject("target").getString("tag");
+        if (webHookPayload != null) {
+            JSONObject data = webHookPayload.getData();
+            if (data != null) {
+                JSONObject target = data.getJSONObject("target");
+                if (target != null) {
+                    this.tag = target.optString("tag");
+                }
+            }
+        }
         this.repoName = repoName;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/registry/notification/webhook/acr/ACRPushNotification.java
+++ b/src/main/java/org/jenkinsci/plugins/registry/notification/webhook/acr/ACRPushNotification.java
@@ -1,0 +1,73 @@
+package org.jenkinsci.plugins.registry.notification.webhook.acr;
+
+import hudson.Util;
+import hudson.model.Cause;
+import hudson.model.ParameterValue;
+import hudson.model.StringParameterValue;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.registry.notification.webhook.PushNotification;
+import org.jenkinsci.plugins.registry.notification.webhook.WebHookPayload;
+
+import javax.annotation.CheckForNull;
+import java.util.HashSet;
+import java.util.Set;
+
+public class ACRPushNotification extends PushNotification {
+    public static final String KEY_REPO_NAME = WebHookPayload.PREFIX + "REPO_NAME";
+    public static final String KEY_DOCKER_REGISTRY_HOST = WebHookPayload.PREFIX + "DOCKER_REGISTRY_HOST";
+    public static final String KEY_TAG = WebHookPayload.PREFIX + "TAG";
+
+    private String registryHost;
+    private String tag;
+
+    public ACRPushNotification(ACRWebHookPayload webHookPayload, String repoName) {
+        super(webHookPayload);
+        this.tag = webHookPayload.getData().getJSONObject("target").getString("tag");
+        this.repoName = repoName;
+    }
+
+    @CheckForNull
+    public String getRegistryHost() {
+        return registryHost;
+    }
+
+    public void setRegistryHost(String registryHost) {
+        this.registryHost = registryHost;
+    }
+
+    public String getTag() {
+        return this.tag;
+    }
+
+    @Override
+    public Cause getCause() {
+        return new ACRWebHookCause(this);
+    }
+
+    @Override
+    public Set<ParameterValue> getRunParameters() {
+        Set<ParameterValue> parameters = new HashSet<ParameterValue>();
+        parameters.add(new StringParameterValue(KEY_REPO_NAME, getRepoName()));
+        parameters.add(new StringParameterValue(KEY_TAG, getTag()));
+        String host = getRegistryHost();
+        if (!StringUtils.isBlank(host)) {
+            parameters.add(new StringParameterValue(KEY_DOCKER_REGISTRY_HOST, host));
+        }
+        return parameters;
+    }
+
+    @Override
+    public String getCauseMessage() {
+        return "Docker image " + getRepoName() + " has been rebuilt by ACR@" + getRegistryHost();
+    }
+
+    public String sha() {
+        return Util.getDigestOf("acrNotification:" + repoName + Long.toBinaryString(getReceived()));
+    }
+
+    @Override
+    public String getShortDescription() {
+        return String.format("push of %s to ACR@%s", getRepoName(), getRegistryHost());
+
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/registry/notification/webhook/acr/ACRWebHook.java
+++ b/src/main/java/org/jenkinsci/plugins/registry/notification/webhook/acr/ACRWebHook.java
@@ -1,0 +1,27 @@
+package org.jenkinsci.plugins.registry.notification.webhook.acr;
+
+import hudson.Extension;;
+import net.sf.json.JSONObject;
+import org.jenkinsci.plugins.registry.notification.webhook.JSONWebHook;
+import org.jenkinsci.plugins.registry.notification.webhook.WebHookPayload;
+
+/**
+ * The ACRWebHook handles incoming updates from the Azure Container Registry. The provided payload differs minimally
+ * from what is transmitted by a standard Docker Registry v2 server, which made this separate implementation necessary.
+ */
+@Extension
+public class ACRWebHook extends JSONWebHook {
+    /**
+     * The namespace under Jenkins context path that this Action is bound to.
+     */
+    public static final String URL_NAME = "acr-webhook";
+
+    @Override
+    protected WebHookPayload createPushNotification(JSONObject payload) {
+        return new ACRWebHookPayload(payload);
+    }
+
+    public String getUrlName() {
+        return URL_NAME;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/registry/notification/webhook/acr/ACRWebHookCause.java
+++ b/src/main/java/org/jenkinsci/plugins/registry/notification/webhook/acr/ACRWebHookCause.java
@@ -1,0 +1,23 @@
+package org.jenkinsci.plugins.registry.notification.webhook.acr;
+
+import org.jenkinsci.plugins.registry.notification.webhook.WebHookCause;
+
+import javax.annotation.Nonnull;
+
+public class ACRWebHookCause extends WebHookCause {
+    public ACRWebHookCause(@Nonnull ACRPushNotification notification) {
+        super(notification);
+    }
+
+    @Override
+    public String getShortDescription() {
+        return String.format("Triggered by %s", getPushNotification().getShortDescription());
+    }
+
+    @Override
+    public String toString() {
+        return "ACRWebHookCause{" +
+                "payload=" + getPushNotification().getWebHookPayload() +
+                '}';
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/registry/notification/webhook/acr/ACRWebHookPayload.java
+++ b/src/main/java/org/jenkinsci/plugins/registry/notification/webhook/acr/ACRWebHookPayload.java
@@ -30,9 +30,7 @@ public class ACRWebHookPayload extends WebHookPayload {
 
     public ACRWebHookPayload(@Nonnull final JSONObject data) {
         setData(data);
-        if (data != null) {
-            setJson(data.toString());
-        }
+        setJson(data.toString());
 
         if (Action.PUSH.getName().equals(data.optString("action"))) {
             final JSONObject event = data;

--- a/src/main/java/org/jenkinsci/plugins/registry/notification/webhook/acr/ACRWebHookPayload.java
+++ b/src/main/java/org/jenkinsci/plugins/registry/notification/webhook/acr/ACRWebHookPayload.java
@@ -35,9 +35,9 @@ public class ACRWebHookPayload extends WebHookPayload {
         if (Action.PUSH.getName().equals(data.optString("action"))) {
             final JSONObject event = data;
             final String host = event.getJSONObject("request").getString("host");
-            final String url = String.format("%s/%s",
-                    host,
-                    event.getJSONObject("target").getString("repository"));
+            final String url = new StringBuilder()
+                    .append(host).append("/").append(event.getJSONObject("target").getString("repository"))
+                    .toString();
             if (logger.isLoggable(Level.FINE)) {
                 logger.log(Level.FINE, "Creating push notification for " + url);
             }

--- a/src/main/java/org/jenkinsci/plugins/registry/notification/webhook/acr/ACRWebHookPayload.java
+++ b/src/main/java/org/jenkinsci/plugins/registry/notification/webhook/acr/ACRWebHookPayload.java
@@ -1,0 +1,55 @@
+package org.jenkinsci.plugins.registry.notification.webhook.acr;
+
+import net.sf.json.JSONObject;
+import org.jenkinsci.plugins.registry.notification.webhook.WebHookPayload;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
+
+import javax.annotation.Nonnull;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Partially implements https://docs.microsoft.com/en-us/azure/container-registry/container-registry-webhook-reference.
+ */
+public class ACRWebHookPayload extends WebHookPayload {
+    private static final Logger logger = Logger.getLogger(ACRWebHookPayload.class.getName());
+
+    public enum Action {
+        PUSH("push");
+        private String name;
+
+        private Action(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return this.name;
+        }
+    }
+
+    public ACRWebHookPayload(@Nonnull final JSONObject data) {
+        setData(data);
+        if (data != null) {
+            setJson(data.toString());
+        }
+
+        if (Action.PUSH.getName().equals(data.optString("action"))) {
+            final JSONObject event = data;
+            final String host = event.getJSONObject("request").getString("host");
+            final String url = String.format("%s/%s",
+                    host,
+                    event.getJSONObject("target").getString("repository"));
+            if (logger.isLoggable(Level.FINE)) {
+                logger.log(Level.FINE, "Creating push notification for " + url);
+            }
+            pushNotifications.add(new ACRPushNotification(this, url){{
+                DateTimeFormatter parser = ISODateTimeFormat.dateTimeParser();
+                setPushedAt(parser.parseDateTime(event.getString("timestamp")).toDate());
+                setRegistryHost(host);
+            }});
+        } else {
+            logger.log(Level.FINER, "Unsupported event received: " + data.toString());
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/registry/notification/webhook/dockerregistry/DockerRegistryWebHookPayload.java
+++ b/src/main/java/org/jenkinsci/plugins/registry/notification/webhook/dockerregistry/DockerRegistryWebHookPayload.java
@@ -46,9 +46,8 @@ public class DockerRegistryWebHookPayload extends WebHookPayload {
     public DockerRegistryWebHookPayload(@Nonnull JSONObject data) {
         super();
         setData(data);
-        if (data != null) {
-            setJson(data.toString());
-        }
+        setJson(data.toString());
+
         JSONArray events = data.getJSONArray("events");
 
         for (int i = 0, size = events.size(); i < size; i++) {

--- a/src/main/resources/org/jenkinsci/plugins/registry/notification/DockerHubTrigger/help.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/registry/notification/DockerHubTrigger/help.groovy
@@ -47,4 +47,11 @@ ul {
             span(_('dockerRegistryUrlBlurb'))
         }
     }
+    li {
+        em {
+            strong(webHookUrl('acr-webhook'))
+            raw('&nbsp;')
+            span(_('acrUrlBlurb'))
+        }
+    }
 }

--- a/src/main/resources/org/jenkinsci/plugins/registry/notification/DockerHubTrigger/help.properties
+++ b/src/main/resources/org/jenkinsci/plugins/registry/notification/DockerHubTrigger/help.properties
@@ -22,9 +22,10 @@
 # THE SOFTWARE.
 #
 
-generalBlurb=The job will get triggered when Docker Hub/Registry notifies about Docker image(s) used in this job has been rebuilt.
+generalBlurb=The job will get triggered when Docker Hub/Registry/ACR notifies about Docker image(s) used in this job has been rebuilt.
 details=The Docker Hub does not yet support adding web hooks via the API, so you will need to configure that manually;\
             In your Docker Hub repository, you can find the "webhooks" section and point it to your jenkins instance,\
             set it to one of the below endpoints.
 dockerHubUrlBlurb=On Docker Hub
 dockerRegistryUrlBlurb=On Docker Registry
+acrUrlBlurb=On Azure Container Registry

--- a/src/test/java/org/jenkinsci/plugins/registry/notification/ACRWebHookTest.java
+++ b/src/test/java/org/jenkinsci/plugins/registry/notification/ACRWebHookTest.java
@@ -1,0 +1,88 @@
+package org.jenkinsci.plugins.registry.notification;
+
+import hudson.model.Cause;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.listeners.RunListener;
+import net.sf.json.JSONObject;
+import org.apache.commons.io.IOUtils;
+import org.jenkinsci.plugins.registry.notification.opt.TriggerOption;
+import org.jenkinsci.plugins.registry.notification.opt.impl.TriggerOnSpecifiedImageNames;
+import org.jenkinsci.plugins.registry.notification.webhook.Http;
+import org.jenkinsci.plugins.registry.notification.webhook.acr.ACRPushNotification;
+import org.jenkinsci.plugins.registry.notification.webhook.acr.ACRWebHook;
+import org.jenkinsci.plugins.registry.notification.webhook.acr.ACRWebHookCause;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.MockBuilder;
+import org.jvnet.hudson.test.TestExtension;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Testing ACR webhook.
+ */
+public class ACRWebHookTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    private String getWebHookURL() throws IOException {
+        return this.j.getURL() + ACRWebHook.URL_NAME + "/notify";
+    }
+
+    @Test
+    public void testValidRepoUpdate() throws Exception {
+        PushNotificationRunListener listener = j.jenkins.getExtensionList(PushNotificationRunListener.class).get(0);
+        listener.reset();
+        createProjectWithTrigger(new TriggerOnSpecifiedImageNames(Collections.singletonList("myregistry.azurecr.io/hello-world")));
+        JSONObject data = JSONObject.fromObject(IOUtils.toString(getClass().getResourceAsStream("/acr-payload-valid.json")));
+        assertEquals(200, Http.post(getWebHookURL(), data));
+        j.waitUntilNoActivity();
+        ACRPushNotification notification = listener.getPushNotification();
+        assertNotNull(notification);
+        assertEquals("v1", notification.getTag());
+
+    }
+
+    private void createProjectWithTrigger(TriggerOption... options) throws Exception {
+        FreeStyleProject project = this.j.createFreeStyleProject();
+        project.addTrigger(new DockerHubTrigger(options));
+        project.getBuildersList().add(new MockBuilder(Result.SUCCESS));
+    }
+
+    @TestExtension
+    public static class PushNotificationRunListener extends RunListener<Run<?,?>> {
+        private List<Run> hits;
+
+        public PushNotificationRunListener() {
+            this.hits = new ArrayList<Run>();
+        }
+
+        @Override
+        public void onFinalized(Run<?, ?> run) {
+            super.onFinalized(run);
+            this.hits.add(run);
+        }
+
+        public void reset() {
+            this.hits.clear();
+        }
+
+        public ACRPushNotification getPushNotification() {
+            for (Run hit : this.hits) {
+                ACRWebHookCause cause = (ACRWebHookCause) hit.getCause(ACRWebHookCause.class);
+                return (ACRPushNotification) cause.getPushNotification();
+            }
+            return null;
+        }
+    }
+}
+

--- a/src/test/java/org/jenkinsci/plugins/registry/notification/ACRWebHookTest.java
+++ b/src/test/java/org/jenkinsci/plugins/registry/notification/ACRWebHookTest.java
@@ -49,6 +49,7 @@ public class ACRWebHookTest {
         ACRPushNotification notification = listener.getPushNotification();
         assertNotNull(notification);
         assertEquals("v1", notification.getTag());
+        assertEquals("myregistry.azurecr.io", notification.getRegistryHost());
 
     }
 

--- a/src/test/resources/acr-payload-valid.json
+++ b/src/test/resources/acr-payload-valid.json
@@ -1,0 +1,19 @@
+{
+  "id": "52ba983c-67d6-11e8-8c71-4a0006ae5a20",
+  "timestamp": "2018-06-04T09:04:00.000000000Z",
+  "action": "push",
+  "target": {
+    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+    "size": 524,
+    "digest": "sha256:f5233545e43561214ca4891fd1157e1c3c563316ed8e237750d59bde73361e77",
+    "length": 524,
+    "repository": "hello-world",
+    "tag": "v1"
+  },
+  "request": {
+    "id": "5d97eae8-67d6-11e8-b1ec-4a0006ae5a20",
+    "host": "myregistry.azurecr.io",
+    "method": "PUT",
+    "useragent": "some user agent"
+  }
+}


### PR DESCRIPTION
Hi :)

Looks like ACR has its own webhook format which is basically the same as the one provided by Docker Registry v2 but without the `events` wrapper. This PR adds support for this format.