### PR TITLE
dockerregistry: add TAG to parameters

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/registry/notification/TriggerStore.java
+++ b/src/main/java/org/jenkinsci/plugins/registry/notification/TriggerStore.java
@@ -97,7 +97,7 @@ public final class TriggerStore extends Descriptor<TriggerStore>
     /**
      * When a build has been removed from jenkins it should also be removed from this store.
      *
-     * @param payload
+     * @param payload the payload
      * @param run the build.
      */
     public synchronized void removed(@Nonnull final PushNotification payload, Run<?, ?> run) {

--- a/src/main/java/org/jenkinsci/plugins/registry/notification/webhook/JSONWebHook.java
+++ b/src/main/java/org/jenkinsci/plugins/registry/notification/webhook/JSONWebHook.java
@@ -85,6 +85,9 @@ public abstract class JSONWebHook implements UnprotectedRootAction {
     /**
      * Stapler entry for the multi build result page
      * @param sha the id of the trigger data.
+     * @return the details
+     * @throws IOException if so
+     * @throws InterruptedException if so
      */
     @Nonnull
     public ResultPage getDetails(@Nonnull final String sha) throws IOException, InterruptedException {
@@ -135,6 +138,7 @@ public abstract class JSONWebHook implements UnprotectedRootAction {
     /**
      * If someone wanders in to the index page, redirect to Jenkins root.
      *
+     * @param request the request object
      * @param response the response object
      * @throws IOException if so
      */

--- a/src/main/java/org/jenkinsci/plugins/registry/notification/webhook/PushNotification.java
+++ b/src/main/java/org/jenkinsci/plugins/registry/notification/webhook/PushNotification.java
@@ -99,6 +99,7 @@ public abstract class PushNotification {
 
     /**
      * String like "username/reponame"
+     * @return the name of the repo
      */
     public String getRepoName() {
         return repoName;

--- a/src/main/java/org/jenkinsci/plugins/registry/notification/webhook/dockerregistry/DockerRegistryPushNotification.java
+++ b/src/main/java/org/jenkinsci/plugins/registry/notification/webhook/dockerregistry/DockerRegistryPushNotification.java
@@ -44,12 +44,23 @@ public class DockerRegistryPushNotification extends PushNotification {
     private static final long serialVersionUID = 207798312860576090L;
     private static final Logger logger = Logger.getLogger(DockerRegistryPushNotification.class.getName());
     public static final String KEY_REPO_NAME = WebHookPayload.PREFIX + "REPO_NAME";
+    public static final String KEY_TAG = WebHookPayload.PREFIX + "TAG";
     public static final String KEY_DOCKER_REGISTRY_HOST = WebHookPayload.PREFIX + "DOCKER_REGISTRY_HOST";
     private String registryHost;
+    private String tag;
 
     public DockerRegistryPushNotification(DockerRegistryWebHookPayload webHookPayload, String repoName) {
         super(webHookPayload);
         this.repoName = repoName;
+    }
+
+    @CheckForNull
+    public String getTag() {
+        return tag;
+    }
+
+    public void setTag(String tag) {
+        this.tag = tag;
     }
 
     @CheckForNull
@@ -70,6 +81,10 @@ public class DockerRegistryPushNotification extends PushNotification {
     public Set<ParameterValue> getRunParameters() {
         Set<ParameterValue> parameters = new HashSet<ParameterValue>();
         parameters.add(new StringParameterValue(KEY_REPO_NAME, getRepoName()));
+        String tag = getTag();
+        if (!StringUtils.isBlank(tag)) {
+            parameters.add(new StringParameterValue(KEY_TAG, tag));
+        }
         String host = getRegistryHost();
         if (!StringUtils.isBlank(host)) {
             parameters.add(new StringParameterValue(KEY_DOCKER_REGISTRY_HOST, host));

--- a/src/main/java/org/jenkinsci/plugins/registry/notification/webhook/dockerregistry/DockerRegistryWebHookPayload.java
+++ b/src/main/java/org/jenkinsci/plugins/registry/notification/webhook/dockerregistry/DockerRegistryWebHookPayload.java
@@ -77,8 +77,10 @@ public class DockerRegistryWebHookPayload extends WebHookPayload {
     private DockerRegistryPushNotification createPushNotification(@Nonnull final String repoName, @Nonnull JSONObject data) {
         final String timestamp = data.optString("timestamp");
         final String host = data.getJSONObject("request").optString("host");
+        final String tag = data.getJSONObject("target").optString("tag");
         return new DockerRegistryPushNotification(this, repoName){{
             DateTimeFormatter parser = ISODateTimeFormat.dateTimeParser();
+            setTag(tag);
             setPushedAt(parser.parseDateTime(timestamp).toDate());
             setRegistryHost(host);
         }};


### PR DESCRIPTION
Propagate TAG in `DockerRegistryPushNotification` similarly to what `ACRPushNotification` and `DockerHubPushNotification` already do.