### PR TITLE
Fix tables to divs issues since Jenkins 2.271

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/registry/notification/DockerHubTrigger/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/registry/notification/DockerHubTrigger/config.groovy
@@ -36,7 +36,7 @@ defaultOption[TriggerForAllUsedInJob.DescriptorImpl.instance] = new TriggerForAl
 
 DockerHubTrigger trigger = instance;
 
-if (context.getVariableWithDefaultValue("divBasedFormLayout", "false") == "true") {
+if (context.getVariableWithDefaultValue("divBasedFormLayout", false) == true) {
     f.descriptorList(title: null,
             field: "options",
             descriptors: TriggerOptionDescriptor.all(),

--- a/src/main/resources/org/jenkinsci/plugins/registry/notification/opt/impl/TriggerOnSpecifiedImageNames/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/registry/notification/opt/impl/TriggerOnSpecifiedImageNames/config.groovy
@@ -27,7 +27,7 @@ def st = namespace("jelly:stapler")
 def f = namespace(lib.FormTagLib)
 def l = namespace("/lib/local")
 
-if (context.getVariableWithDefaultValue("divBasedFormLayout", "false") == "true") {
+if (context.getVariableWithDefaultValue("divBasedFormLayout", false) == true) {
     f.entry(title:_("Repositories"), field: "repoNames") {
         f.expandableTextbox(value: instance?.repoNames?.join("\n"))
     }


### PR DESCRIPTION
The type of the `divBasedFormLayout` was changed from String to Boolean on Jenkins 2.271 by https://github.com/jenkinsci/jenkins/pull/5075. This caused the plugin to stop resolving the condition as true, as it was trying to evaluate `true == "true"`. 

I ran a code search across the plugin ecosystem and no other plugin uses this variable on a groovy file. No jelly plugins seem to be affected.