### PR TITLE
started work on support for jobdsl

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,14 @@ The plugin can be tested with
 ```bash
     curl -X POST -H "Content-Type: application/json" http://localhost:8080/jenkins/dockerhub-webhook/notify -d @src/test/resources/public-repository-payload.json
 ```
+
+## Job DSL (TOOD)
+
+The current supported dsl could be as follows:
+```
+freeStyleJob('test-job'){
+  triggers{
+    registryPush()
+  }
+}
+```

--- a/TODO.md
+++ b/TODO.md
@@ -1,19 +1,23 @@
-#TODO
+# TODO
 
-##Auto Hook
+## Auto Hook
+
 Currently the [Docker Hub API](https://docs.docker.com/docker-hub/repos/#webhooks) doesn't support adding web hooks. 
 When support for that is added this plugin should be updated to *automagically* add the hook when configured.
  
-##Hook origin Security
+## Hook origin Security
+
 The plugin currently blindly accept a wel formed HTTP POST to the end point that contains expected data.
 Some measures should be taken to be a bit more secure. Two examples that could both be implemented.
  
-###Origin IP check
+### Origin IP check
+
 The [Docker Hub API](https://docs.docker.com/docker-hub/repos/#webhooks) documentation mentions an IP range that all their hooks are coming from.
 Implement an IP range check that ignores HTTP POSTs from clients not in that range.
 The ranges should be configurable by an admin in case of for example internal proxies.
 Work has been started on the `from-trusted-ip` branch.
 
-###Poll Docker Hub when a hook arrives to verify that something has actually happened.
+### Poll Docker Hub when a hook arrives to verify that something has actually happened.
+
 This could be tricky due to the CDN that Docker Hub is using. At least from a user's perspective 
 information isn't updated in the UI until minutes after the actual push and web hook post.


### PR DESCRIPTION
I want to configure all my jobs via configuration-as-code and seed jobs with job-dsl. The bitbucket-plugin supports this already [link](https://github.com/jenkinsci/bitbucket-plugin/tree/master#job-dsl). This plugin however does not seem to understand job-dsl, as the snippet generator produces only garbage. That's why I think this functionality is missing. I do not know how to implement this feature and this pull request is the only way I found out to contact the developers. So feel free to reject this request. But if this feature is wanted, I would appreciate some hints to get started in developing jenkins plugins so I can help.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
