### PR TITLE
Make unit test compatible with Jenkins 2.309+

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/registry/notification/webhook/WebHookPayloadTest.java
+++ b/src/test/java/org/jenkinsci/plugins/registry/notification/webhook/WebHookPayloadTest.java
@@ -23,8 +23,7 @@
  */
 package org.jenkinsci.plugins.registry.notification.webhook;
 
-
-import com.thoughtworks.xstream.XStream;
+import hudson.util.XStream2;
 import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.registry.notification.webhook.dockerhub.DockerHubWebHookPayload;
 import org.junit.Test;
@@ -35,6 +34,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
 public class WebHookPayloadTest {
+
     @Test
     public void testSerialization() throws Exception {
         JSONObject json = new JSONObject();
@@ -43,7 +43,7 @@ public class WebHookPayloadTest {
         json.put("repository", repository);
         WebHookPayload obj = new DockerHubWebHookPayload(json);
 
-        XStream xs = new XStream();
+        XStream2 xs = new XStream2();
         xs.allowTypes(new Class[] {DockerHubWebHookPayload.class});
         String xml = xs.toXML(obj);
         assertThat(xml, not(containsString("<data>")));

--- a/src/test/java/org/jenkinsci/plugins/registry/notification/webhook/WebHookPayloadTest.java
+++ b/src/test/java/org/jenkinsci/plugins/registry/notification/webhook/WebHookPayloadTest.java
@@ -44,6 +44,7 @@ public class WebHookPayloadTest {
         WebHookPayload obj = new DockerHubWebHookPayload(json);
 
         XStream xs = new XStream();
+        xs.allowTypes(new Class[] {DockerHubWebHookPayload.class});
         String xml = xs.toXML(obj);
         assertThat(xml, not(containsString("<data>")));
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
If you run `WebHookPayloadTest` under Jenkins 2.309, you will get:
`com.thoughtworks.xstream.security.ForbiddenClassException: org.jenkinsci.plugins.registry.notification.webhook.dockerhub.DockerHubWebHookPayload`

This is related to the XStream change in 1.4.18 going from denylist to allowlist. 
Was not successful in adding `DockerHubWebHookPayload` to the XStream allowlist. Switched to using `hudson.Xstream2`
cc @rsandell 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
