### PR TITLE
Plugin doc migration from wiki to github

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ This plugin provides integration between
 It does so by utilizing webhooks to trigger one (or more) Jenkins job(s).
 This allows you to implement continuous delivery pipelines based on Docker in Jenkins.
 
-Upon receiving a notification of an updated image as web-hook from
-Docker Hub, Jenkins will trigger all jobs that have the Docker Hub
-trigger enabled that also use the Docker image as part of the build. A
+When Jenkins receives a notification of an updated image that is a web-hook from
+Docker Hub, it triggers all jobs that have the Docker Hub
+trigger enabled and use the Docker image as part of the build. A
 Docker Hub Pull build step is provided to retrieve the latest image from
 Hub.
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,14 @@ This plugin provides integration between
 * Jenkins and Docker Hub
 * Jenkins and Docker Registry 2.0
 
-, utilizing webhooks to trigger one (or more) Jenkins job(s).
+It does so by utilizing webhooks to trigger one (or more) Jenkins job(s).
 This allows you to implement continuous delivery pipelines based on Docker in Jenkins.
 
-Upon receiving a new image notification, Jenkins will trigger all jobs that have the Docker Hub/Registry trigger
-enabled and use the incoming Docker image as part of the Build.  A `DockerHub Pull` build step is provided to retrieve
-the latest image from Hub.
+Upon receiving a notification of an updated image as web-hook from
+Docker Hub, Jenkins will trigger all jobs that have the Docker Hub
+trigger enabled that also use the Docker image as part of the build. A
+Docker Hub Pull build step is provided to retrieve the latest image from
+Hub.
 
 # Configuring Docker Hub
 
@@ -39,7 +41,7 @@ The simplest viable configuration looks like this:
 
 You can find a detailed guide on how to configure webhooks on ACR on
 [docs.microsoft.com](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-webhook).
-Use `http://JENKINS/acr-webhook/notify` as "Service URI".
+Use `http://JENKINS/acr-webhook/notify` as a "Service URI".
 
 
 # Examples

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <packaging>hpi</packaging>
 
     <name>CloudBees Docker Hub/Registry Notification</name>
-    <url>https://plugins.jenkins.io/dockerhub-notification/</url>
+    <url>https://github.com/jenkinsci/dockerhub-notification-plugin/</url>
 
     <properties>
         <jenkins.version>2.222.4</jenkins.version>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <packaging>hpi</packaging>
 
     <name>CloudBees Docker Hub/Registry Notification</name>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Docker+Hub+Notification</url>
+    <url>https://plugins.jenkins.io/dockerhub-notification/</url>
 
     <properties>
         <jenkins.version>2.222.4</jenkins.version>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
- Migrated some doc from https://github.com/jenkins-infra/plugins-wiki-docs/tree/master/dockerhub-notification to update README.md
- Updated pom.xml with the new link.
- Did minor grammatical changes

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did


<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
