### PR TITLE
Move from async-http-client to okhttp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,9 +81,9 @@
             <version>1.16</version>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>async-http-client</artifactId>
-            <version>1.7.24.3</version>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>okhttp-api</artifactId>
+            <version>3.14.9-20211029</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>


### PR DESCRIPTION
Hello :wave: 

The dockerhub-notification-plugin currently uses the async-http-client plugin for network interactions. The async-http-client plugin is known to be incompatible with Java 11 (in the version currently available in the Jenkins ecosystem).

Linked to the JDK11 support effort, there is a work in progress aiming at replacing async-http-client with okhttp in Jenkins plugins, using the okhttp-plugin from Jenkins.

So here comes a Pull Request with a replacement of AHC with okhttp for this plugin :) (link to Jira ticket: https://issues.jenkins.io/browse/JENKINS-67031)

Let me know in case you have any question/remark or you'd like some modification :)

Have a great day!

All tests of the project are still running fine with that change :)

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
