### PR TITLE
Bump parent from 4.40 to 4.47 to fix flaky DockerHubWebHookTest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.40</version>
+        <version>4.47</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
4.47 got the fixed jenkins-test-harness to remove flakiness in DockerHubWebHookTest
