### PR TITLE
Test with Java 21

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 buildPlugin(useContainerAgent: true, configurations: [
-  [platform: 'linux', jdk: 17],
-  [platform: 'windows', jdk: 11],
+  [platform: 'linux', jdk: 21],
+  [platform: 'windows', jdk: 17],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.387.x</artifactId>
-                <version>2198.v39c76fc308ca</version>
+                <version>2483.v3b_22f030990a_</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.69</version>
+        <version>4.74</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.387.x</artifactId>
-                <version>2483.v3b_22f030990a_</version>
+                <version>2507.vcb_18c56b_f57c</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -95,11 +95,6 @@
             <artifactId>structs</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.jenkins</groupId>
             <artifactId>configuration-as-code</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>docker-commons</artifactId>
-            <version>1.21</version>
         </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/registry/notification/webhook/acr/ACRWebHook.java
+++ b/src/main/java/org/jenkinsci/plugins/registry/notification/webhook/acr/ACRWebHook.java
@@ -1,6 +1,6 @@
 package org.jenkinsci.plugins.registry.notification.webhook.acr;
 
-import hudson.Extension;;
+import hudson.Extension;
 import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.registry.notification.webhook.JSONWebHook;
 import org.jenkinsci.plugins.registry.notification.webhook.WebHookPayload;

--- a/src/test/java/org/jenkinsci/plugins/registry/notification/DockerHubTriggerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/registry/notification/DockerHubTriggerTest.java
@@ -34,9 +34,9 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import static org.hamcrest.collection.IsEmptyCollection.empty;
-import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 
 /**
  * Tests for {@link DockerHubTrigger}.

--- a/src/test/java/org/jenkinsci/plugins/registry/notification/RegistryWebHookTest.java
+++ b/src/test/java/org/jenkinsci/plugins/registry/notification/RegistryWebHookTest.java
@@ -50,7 +50,8 @@ import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.hamcrest.core.AllOf.allOf;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Testing Registry v2 webhook.

--- a/src/test/java/org/jenkinsci/plugins/registry/notification/webhook/WebHookPayloadTest.java
+++ b/src/test/java/org/jenkinsci/plugins/registry/notification/webhook/WebHookPayloadTest.java
@@ -30,8 +30,8 @@ import org.junit.Test;
 
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.StringContains.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 
 public class WebHookPayloadTest {
 


### PR DESCRIPTION
## Test with Java 21

- Test with Java 21 and Java 17
- Use parent pom 4.74 (need one of the newer parent poms for Java 21)
- Remove hamcrest declaration, provided by parent
- Rely on bom declaration of docker-commons version
- Use most recent plugin bom release 2483.x

### Testing done

Confirmed that tests pass with Java 21 on Linux.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
