### PR TITLE
Prevent null pointer exception in docker workflow plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 buildPlugin(useContainerAgent: true, configurations: [
-  [platform: 'linux', jdk: 17],
-  [platform: 'windows', jdk: 11],
+  [platform: 'linux', jdk: 21],
+  [platform: 'windows', jdk: 17],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.387.x</artifactId>
-                <version>2198.v39c76fc308ca</version>
+                <version>2483.v3b_22f030990a_</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.69</version>
+        <version>4.74</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,12 @@
             <artifactId>test-harness</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- DockerHubTriggerTest test previously failed with NPE with this test dependency included -->
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>docker-workflow</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.387.x</artifactId>
-                <version>2483.v3b_22f030990a_</version>
+                <version>2507.vcb_18c56b_f57c</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -95,11 +95,6 @@
             <artifactId>structs</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.jenkins</groupId>
             <artifactId>configuration-as-code</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>docker-commons</artifactId>
-            <version>1.21</version>
         </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/registry/notification/opt/impl/TriggerForAllUsedInJob.java
+++ b/src/main/java/org/jenkinsci/plugins/registry/notification/opt/impl/TriggerForAllUsedInJob.java
@@ -34,6 +34,7 @@ import org.jenkinsci.plugins.registry.notification.opt.TriggerOptionDescriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.util.Collection;
+import java.util.Collections;
 
 /**
  * {@link TriggerOption} to trigger on all images reported by all {@link DockerImageExtractor}s for the job.
@@ -48,6 +49,11 @@ public class TriggerForAllUsedInJob extends TriggerOption {
 
     @Override
     public Collection<String> getRepoNames(Job<?, ?> job) {
+        if (job == null) {
+            // DockerImageExtractor.getDockerImagesUsedByJobFromAll expects a non-null job argument
+            // Return an empty list if the job argument is null
+            return Collections.emptyList();
+        }
         return DockerImageExtractor.getDockerImagesUsedByJobFromAll(job);
     }
 

--- a/src/main/java/org/jenkinsci/plugins/registry/notification/webhook/acr/ACRWebHook.java
+++ b/src/main/java/org/jenkinsci/plugins/registry/notification/webhook/acr/ACRWebHook.java
@@ -1,6 +1,6 @@
 package org.jenkinsci.plugins.registry.notification.webhook.acr;
 
-import hudson.Extension;;
+import hudson.Extension;
 import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.registry.notification.webhook.JSONWebHook;
 import org.jenkinsci.plugins.registry.notification.webhook.WebHookPayload;

--- a/src/test/java/org/jenkinsci/plugins/registry/notification/DockerHubTriggerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/registry/notification/DockerHubTriggerTest.java
@@ -34,9 +34,9 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import static org.hamcrest.collection.IsEmptyCollection.empty;
-import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 
 /**
  * Tests for {@link DockerHubTrigger}.

--- a/src/test/java/org/jenkinsci/plugins/registry/notification/RegistryWebHookTest.java
+++ b/src/test/java/org/jenkinsci/plugins/registry/notification/RegistryWebHookTest.java
@@ -50,7 +50,8 @@ import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.hamcrest.core.AllOf.allOf;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Testing Registry v2 webhook.

--- a/src/test/java/org/jenkinsci/plugins/registry/notification/webhook/WebHookPayloadTest.java
+++ b/src/test/java/org/jenkinsci/plugins/registry/notification/webhook/WebHookPayloadTest.java
@@ -30,8 +30,8 @@ import org.junit.Test;
 
 import static org.hamcrest.core.IsNot.not;
 import static org.hamcrest.core.StringContains.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 
 public class WebHookPayloadTest {
 


### PR DESCRIPTION
## Prevent null pointer exception in docker workflow plugin

A method that expects a non-null `job` argument was being passed a null `job` argument.  Now returns an empty list when a null `job` is passed.

This will need to be released so that this plugin can be included in the Jenkins plugin bill of materials.  More details are available at:

* https://github.com/jenkinsci/bom/issues/2439

This pull request should be merged after the merge of:

* #43 

### Testing done

Confirmed that `DockerHubTriggerTest` fails before this change and passes after the change.  Command is:

```bash
mvn clean -Dtest=DockerHubTriggerTest verify
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
