### PR TITLE
Removes Yahoo UI usages from dockerhub-notification plugin

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/registry/notification/token/ApiTokens/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/registry/notification/token/ApiTokens/config.jelly
@@ -19,7 +19,7 @@
                                 </span>
                                 <f:textbox readonly="true" value="${apiToken.name}" />
                                 <!-- onclick handler for that button is defined in resources.js -->
-                                <a href="#" class="yui-button dockerhub-api-token-revoke-button"
+                                <a href="#" class="jenkins-button jenkins-button jenkins-!-margin-left-1 dockerhub-api-token-revoke-button"
                                    data-confirm="${%Are you sure you want to revoke this access token?}"
                                    data-target-url="${descriptor.descriptorFullUrl}/revoke">
                                     ${%Revoke}
@@ -32,9 +32,9 @@
                                     <input type="hidden" class="dockerhub-api-token-uuid-input" name="apiTokenUuid" value="${apiToken.uuid}" />
                                     <f:textbox clazz="dockerhub-api-token-name-input" name="apiTokenName" placeholder="${%Access token name}"/>
                                     <span class="dockerhub-new-api-token-value hidden"><!-- to be filled by JS --></span>
-                                    <span class="yui-button dockerhub-api-token-save-button">
+                                    <span class="dockerhub-api-token-save-button">
                                         <!-- onclick handler for that button is defined in resources.js -->
-                                        <button type="button" tabindex="0" data-target-url="${descriptor.descriptorFullUrl}/generate">
+                                        <button type="button" class="jenkins-button jenkins-button jenkins-!-margin-left-1" tabindex="0" data-target-url="${descriptor.descriptorFullUrl}/generate">
                                             ${%Generate}
                                         </button>
                                     </span>
@@ -43,7 +43,7 @@
                                     </span>
                                     <l:copyButton message="${%Copied}" text="" clazz="hidden" tooltip="${%Copy to clipboard}" />
                                     <!-- onclick handler for that button is defined in resources.js -->
-                                    <a href="#" class="yui-button dockerhub-api-token-revoke-button hidden"
+                                    <a href="#" class="jenkins-button jenkins-button jenkins-!-margin-left-1 dockerhub-api-token-revoke-button hidden"
                                        data-confirm="${%Are you sure you want to revoke this access token?}"
                                        data-target-url="${descriptor.descriptorFullUrl}/revoke">
                                         ${%Revoke}


### PR DESCRIPTION
## Changes
- Replaced yui-button css references with jenking-button 

### Testing done

Before
<img width="1486" alt="image" src="https://github.com/user-attachments/assets/6989a83c-5745-4741-a14e-aeb78fa6d535" />

After
<img width="843" alt="image" src="https://github.com/user-attachments/assets/883ee5d3-51a4-4ec9-b769-26a53daf06df" />


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
